### PR TITLE
add quotes to variables expensions and refactor glpi_console function

### DIFF
--- a/glpi-server/start_glpi-server.sh
+++ b/glpi-server/start_glpi-server.sh
@@ -4,9 +4,9 @@
 # $1 : Command to run
 glpi_console() {
 	# We want this to output "${@}" without expansion
-  # shellcheck disable=SC2016
-  cd '/var/www/glpi' &&
-    su 'apache' -s '/bin/ash' -c '"${@}"' -- '/usr/bin/php' '/var/www/glpi/bin/console' "${@}"
+	# shellcheck disable=SC2016
+	cd '/var/www/glpi' &&
+		su 'apache' -s '/bin/ash' -c '"${@}"' -- '/usr/bin/php' '/var/www/glpi/bin/console' "${@}"
 }
 
 
@@ -52,23 +52,23 @@ then
 fi
 if [ -z "${MYSQL_PORT}" ]
 then
-    MYSQL_PORT="3306"
+	MYSQL_PORT="3306"
 fi
 if [ -z "${MYSQL_DATABASE}" ]
 then
-    MYSQL_DATABASE="glpi"
+	MYSQL_DATABASE="glpi"
 fi
 if [ -z "${MYSQL_USER}" ]
 then
-    MYSQL_USER="glpi"
+	MYSQL_USER="glpi"
 fi
 if [ -z "${MYSQL_PASSWORD}" ]
 then
-    MYSQL_PASSWORD="glpi-password"
+	MYSQL_PASSWORD="glpi-password"
 fi
 if [ -z "${LANG}" ]
 then
-    LANG="fr_FR"
+	LANG="fr_FR"
 fi
 if [ -z "${TZ}" ]
 then
@@ -114,7 +114,7 @@ fi
 if [ -n "${MYSQL_ROOT_PASSWORD}" ]
 then
 	# Allow GLPI user to access to GLPI database
-	mysql --host="${MYSQL_HOST}" --port="${MYSQL_PORT}" --user=root --password="${MYSQL_ROOT_PASSWORD}"  << EOF
+	mysql --host="${MYSQL_HOST}" --port="${MYSQL_PORT}" --user=root --password="${MYSQL_ROOT_PASSWORD}"	<< EOF
 GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE TEMPORARY TABLES, CREATE VIEW, DELETE, DROP, EVENT, EXECUTE, INDEX, INSERT, LOCK TABLES, REFERENCES, SELECT, SHOW VIEW, TRIGGER, UPDATE ON \`${MYSQL_DATABASE}\`.* TO '${MYSQL_USER}';
 USE mysql;
 GRANT SELECT ON mysql.time_zone_name TO '${MYSQL_USER}';

--- a/glpi-server/start_glpi-server.sh
+++ b/glpi-server/start_glpi-server.sh
@@ -3,7 +3,10 @@
 # Run a GLPI console command
 # $1 : Command to run
 glpi_console() {
-	su apache -s /bin/ash -c "cd /var/www/glpi; bin/console $1"
+	# We want this to output "${@}" without expansion
+  # shellcheck disable=SC2016
+  cd '/var/www/glpi' &&
+    su 'apache' -s '/bin/ash' -c '"${@}"' -- '/usr/bin/php' '/var/www/glpi/bin/console' "${@}"
 }
 
 
@@ -11,39 +14,36 @@ glpi_console() {
 # $1 : folder of the plugin
 # $2 : required version of the plugin
 update_plugin() {
-	ACTUAL_VERSION=$(mysql --host=${MYSQL_HOST} --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --database=${MYSQL_DATABASE} 2>/dev/null << EOF
+	ACTUAL_VERSION=$(mysql --host="${MYSQL_HOST}" --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --database="${MYSQL_DATABASE}" 2>/dev/null << EOF
 SELECT version FROM glpi_plugins WHERE directory LIKE '$1';
 EOF
 	)
-	ACTUAL_VERSION=$(echo ${ACTUAL_VERSION} | cut -d' ' -f2)
+	ACTUAL_VERSION="$(echo "${ACTUAL_VERSION}" | cut -d' ' -f2)"
 	if [ "$2" != "${ACTUAL_VERSION}" ]
 	then
-		echo "Update plugin : " $1
-		glpi_console "glpi:plugin:deactivate $1"
-		cp -a ${HOME}/plugins/$1 /var/www/glpi/plugins
-		glpi_console "glpi:plugin:install -u glpi $1"
-		glpi_console "glpi:plugin:activate $1"
+		echo "Update plugin : $1"
+		glpi_console 'glpi:plugin:deactivate' "$1"
+		cp -a "${HOME}/plugins/$1" '/var/www/glpi/plugins'
+		glpi_console 'glpi:plugin:install' -u 'glpi' "$1"
+		glpi_console 'glpi:plugin:activate' "$1"
 	fi
 }
 
 # Installation is done. Set the proper file to share the information
 install_done() {
-	echo "DO NOT REMOVE" >/etc/glpi/.installation_done
+	echo "DO NOT REMOVE" >'/etc/glpi/.installation_done'
 }
 
 # Update is needed. Unset the proper file to share the information
 update_in_progress() {
-	rm /etc/glpi/.installation_done
+	rm '/etc/glpi/.installation_done'
 }
 
 # Check env variables
-INSTALL_PARAM=''
 if [ -z "${MYSQL_HOST}" ]
 then
 	echo "MYSQL_HOST must be set"
 	exit 1
-else
-	INSTALL_PARAM="${INSTALL_PARAM} --db-host=${MYSQL_HOST}"
 fi
 if [ -z "${MYSQL_ROOT_PASSWORD}" ]
 then
@@ -54,27 +54,22 @@ if [ -z "${MYSQL_PORT}" ]
 then
     MYSQL_PORT="3306"
 fi
-INSTALL_PARAM="${INSTALL_PARAM} --db-port=${MYSQL_PORT}"
 if [ -z "${MYSQL_DATABASE}" ]
 then
     MYSQL_DATABASE="glpi"
 fi
-INSTALL_PARAM="${INSTALL_PARAM} --db-name=${MYSQL_DATABASE}"
 if [ -z "${MYSQL_USER}" ]
 then
     MYSQL_USER="glpi"
 fi
-INSTALL_PARAM="${INSTALL_PARAM} --db-user=${MYSQL_USER}"
 if [ -z "${MYSQL_PASSWORD}" ]
 then
     MYSQL_PASSWORD="glpi-password"
 fi
-INSTALL_PARAM="${INSTALL_PARAM} --db-password=${MYSQL_PASSWORD}"
 if [ -z "${LANG}" ]
 then
     LANG="fr_FR"
 fi
-INSTALL_PARAM="${INSTALL_PARAM} --default-language=${LANG}"
 if [ -z "${TZ}" ]
 then
 	TZ="Europe/Paris"
@@ -93,34 +88,34 @@ sed -i "s|memory_limit = 128M|memory_limit = 256M|" /etc/php81/php.ini
 sed -i "s|max_execution_time = 30|max_execution_time = 600|" /etc/php81/php.ini
 
 # Do the user and the database exist?
-if [ -z "$(mysqlshow --host=${MYSQL_HOST} --port=${MYSQL_PORT} --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} | grep ${MYSQL_DATABASE} 2>/dev/null)" ]
+if [ -z "$(mysqlshow --host="${MYSQL_HOST}" --port="${MYSQL_PORT}" --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" | grep "${MYSQL_DATABASE}" 2>/dev/null)" ]
 then
 	# Does the database exist
-	if [ -z $(mysqlshow --host=${MYSQL_HOST} --port=${MYSQL_PORT} --user=root --password=${MYSQL_ROOT_PASSWORD} | grep ${MYSQL_DATABASE}) ]
+	if [ -z "$(mysqlshow --host="${MYSQL_HOST}" --port="${MYSQL_PORT}" --user=root --password="${MYSQL_ROOT_PASSWORD}" | grep "${MYSQL_DATABASE}")" ]
 	then
 		# Creation of the Database
 		echo "MySQL Database creation : '${MYSQL_DATABASE}'"
-		mysql --host=${MYSQL_HOST} --port=${MYSQL_PORT} --user=root --password=${MYSQL_ROOT_PASSWORD} << EOF
-CREATE DATABASE ${MYSQL_DATABASE};
+		mysql --host="${MYSQL_HOST}" --port="${MYSQL_PORT}" --user=root --password="${MYSQL_ROOT_PASSWORD}" << EOF
+CREATE DATABASE \`${MYSQL_DATABASE}\`;
 EOF
 	fi
 
 	# Does the user exist
-	if [ -z $(mysql --host=${MYSQL_HOST} --user=root --password=${MYSQL_ROOT_PASSWORD} --database=mysql -e "SELECT User FROM user WHERE User LIKE '${MYSQL_USER}'" | grep ${MYSQL_USER}) ]
+	if [ -z "$(mysql --host="${MYSQL_HOST}" --user=root --password="${MYSQL_ROOT_PASSWORD}" --database=mysql -e "SELECT User FROM user WHERE User LIKE '${MYSQL_USER}'" | grep "${MYSQL_USER}")" ]
 	then
 		echo "MySQL user creation : ${MYSQL_USER}"
-		mysql --host=${MYSQL_HOST} --port=${MYSQL_PORT} --user=root --password=${MYSQL_ROOT_PASSWORD} << EOF
+		mysql --host="${MYSQL_HOST}" --port="${MYSQL_PORT}" --user=root --password="${MYSQL_ROOT_PASSWORD}" << EOF
 CREATE USER '${MYSQL_USER}' IDENTIFIED BY '${MYSQL_PASSWORD}';
 EOF
-		mysql --host=${MYSQL_HOST} --user=root --password=${MYSQL_ROOT_PASSWORD} --database=mysql -e "SELECT User FROM user WHERE User LIKE '${MYSQL_USER}'"
+		mysql --host="${MYSQL_HOST}" --user=root --password="${MYSQL_ROOT_PASSWORD}" --database=mysql -e "SELECT User FROM user WHERE User LIKE '${MYSQL_USER}'"
 	fi
 fi
 
 if [ -n "${MYSQL_ROOT_PASSWORD}" ]
 then
 	# Allow GLPI user to access to GLPI database
-	mysql --host=${MYSQL_HOST} --port=${MYSQL_PORT} --user=root --password=${MYSQL_ROOT_PASSWORD}  << EOF
-GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE TEMPORARY TABLES, CREATE VIEW, DELETE, DROP, EVENT, EXECUTE, INDEX, INSERT, LOCK TABLES, REFERENCES, SELECT, SHOW VIEW, TRIGGER, UPDATE ON ${MYSQL_DATABASE}.* TO '${MYSQL_USER}';
+	mysql --host="${MYSQL_HOST}" --port="${MYSQL_PORT}" --user=root --password="${MYSQL_ROOT_PASSWORD}"  << EOF
+GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE TEMPORARY TABLES, CREATE VIEW, DELETE, DROP, EVENT, EXECUTE, INDEX, INSERT, LOCK TABLES, REFERENCES, SELECT, SHOW VIEW, TRIGGER, UPDATE ON \`${MYSQL_DATABASE}\`.* TO '${MYSQL_USER}';
 USE mysql;
 GRANT SELECT ON mysql.time_zone_name TO '${MYSQL_USER}';
 FLUSH PRIVILEGES;
@@ -128,29 +123,29 @@ EOF
 fi
 
 # Check GLPI actual version
-GLPI_ACTUAL_VERSION=$(mysql --host=${MYSQL_HOST} --port=${MYSQL_PORT} --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --database=${MYSQL_DATABASE} 2>/dev/null << EOF
+GLPI_ACTUAL_VERSION="$(mysql --host="${MYSQL_HOST}" --port="${MYSQL_PORT}" --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" --database="${MYSQL_DATABASE}" 2>/dev/null << EOF
 SELECT value FROM glpi_configs WHERE name LIKE 'version';
 EOF
-)
-GLPI_ACTUAL_VERSION=$(echo ${GLPI_ACTUAL_VERSION} | cut -d' ' -f2)
+)"
+GLPI_ACTUAL_VERSION="$(echo "${GLPI_ACTUAL_VERSION}" | cut -d' ' -f2)"
 
-echo "Current version :" ${GLPI_ACTUAL_VERSION}
-echo "Docker version :" ${GLPI_VERSION}
+echo "Current version : ${GLPI_ACTUAL_VERSION}"
+echo "Docker version : ${GLPI_VERSION}"
 
 if [ -z "${GLPI_ACTUAL_VERSION}" ]
 then
 	# Install GLPI
 	echo "GLPI installation"
-	cp -a /root/config/* /etc/glpi
-	cp -a /root/files /var/glpi
-	cp -a /root/plugins /var/www/glpi
-	cp -a /root/marketplace /var/www/glpi
-	glpi_console "-n db:install ${INSTALL_PARAM}"
+	cp -a '/root/config/'* '/etc/glpi'
+	cp -a '/root/files' '/var/glpi'
+	cp -a '/root/plugins' '/var/www/glpi'
+	cp -a '/root/marketplace' '/var/www/glpi'
+	glpi_console -n 'db:install' --db-host="${MYSQL_HOST}" --db-port="${MYSQL_PORT}" --db-name="${MYSQL_DATABASE}" --db-user="${MYSQL_USER}" --db-password="${MYSQL_PASSWORD}" --default-language="${LANG}"
 
 	# Install plugins
 	echo "Plugins installation"
-	glpi_console "glpi:plugin:install -u glpi --all"
-	glpi_console "glpi:plugin:activate --all"
+	glpi_console 'glpi:plugin:install' -u 'glpi' --all
+	glpi_console 'glpi:plugin:activate' --all
 
 	# Set the Apache as owner of all files and directories
 	#chown -R apache:apache /var/www/glpi
@@ -176,11 +171,11 @@ else
 		update_in_progress
 
 		# Launch the update
-		glpi_console "-n db:update"
+		glpi_console -n 'db:update'
 
 		# Reactivate all plugins
 		echo "Plugins activation"
-		glpi_console "glpi:plugin:activate --all"
+		glpi_console 'glpi:plugin:activate' --all
 
 		# Set the Apache as owner of all files and directories
 		#chown -R apache:apache /var/www/glpi


### PR DESCRIPTION
Closes #7 Special characters in database password causes install script to fail.

- Add quotes everywhere to prevent issues with spaces and special chars when expending vars.
- refactor glpi_console to allow to pass arguments directly and allow for special chars in arguments.
- checked for issues using shellcheck. There is three [SC2143](https://www.shellcheck.net/wiki/SC2143) warnings, but otherwise the script is OK.
- tested on a GLPI fresh install without issues.